### PR TITLE
Consider using cryptography's Fernet instead of simple-crypt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     install_requires=[
         "click==6.6",
         "tinydb==3.2.1",
-        "simple-crypt==4.1.7"
+        "cryptography>=1.5"
     ],
     classifiers=[
         'Programming Language :: Python',


### PR DESCRIPTION
While simple-crypt looks secure on superficial audit (i'm not 100% sure if passing a random `prefix=` to Counter is the same as passing a random `initial_value`?), cryptography allows more flexibility while being  a lot more commonly used (so, more widely deployed & audited for security).

This implementation caches the key on the `Stash` instance, so subsequent uses (from a python script) don't need to derive the key again. This makes it much more performant when using a python script to retrieve multiple keys, without sacrificing security (there's no security value in deriving the key on each use).

Alternative implementation might use gpg, for interop with gpg-agent, so we might also want to consider that instead.