### PR TITLE
Redo sqlalchemy path parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ stash.delete('aws')
 
 ## Backends
 
-NOTE: ghost includes dependencies required for TinyDB only. `
+NOTE: ghost includes dependencies required for TinyDB only as its installation should be light-weight by default. `
 You can install extras for each specific backend. See below.
 
 NOTE: Whlie true for the API, the CLI does not currently expose any advanced configuration for the Vault and Consul backends such as setting certs, credentials or paths.
@@ -195,6 +195,8 @@ The TinyDB backend provides an easy to read, portable JSON file based stash. It 
 ### [SQLAlchemy](http://www.sqlalchemy.org)
 
 (Initially tested on v1.0.15)
+
+NOTE: To use postgre, mysql or the likes, you must have the relevant package installed for SQLAlchemy to work. For instance, providing `postgresql://scott:tiger@localhost/mydatabase` as the path to the backend requires installing `psycopg2` to be installed. Failing to install the relevant package will result in SQLAlchemy raising an error which will state what's missing.
 
 To enable, run `pip install ghost[sqlalchemy]`
 

--- a/tests/test_ghost.py
+++ b/tests/test_ghost.py
@@ -235,12 +235,12 @@ class TestSQLAlchemyStorage:
         tmpdir = os.path.join(tempfile.mkdtemp())
         shutil.rmtree(tmpdir)
         assert not os.path.isdir(tmpdir)
-        stash_path = 'sqlite:///' + os.path.join(tmpdir, 'stash.json')
+        stash_path = os.path.join(tmpdir, 'stash.json')
         storage = ghost.SQLAlchemyStorage(stash_path)
         try:
             storage.init()
             assert os.path.isdir(tmpdir)
-            engine = create_engine(stash_path)
+            engine = create_engine('sqlite:///' + stash_path)
             inspector = inspect(engine)
             tables = inspector.get_table_names()
             assert 'keys' in tables
@@ -258,7 +258,7 @@ class TestSQLAlchemyStorage:
     def test_init_stash_already_exists(self):
         fd, stash_path = tempfile.mkstemp()
         os.close(fd)
-        storage = ghost.SQLAlchemyStorage('sqlite://' + stash_path)
+        storage = ghost.SQLAlchemyStorage('sqlite:///' + stash_path)
         with pytest.raises(ghost.GhostError) as ex:
             storage.init()
         assert 'Stash {0} already initialized'.format(stash_path) \
@@ -268,7 +268,7 @@ class TestSQLAlchemyStorage:
     def test_init_stash_create_directory(self):
         stash_dir = tempfile.mkdtemp()
         shutil.rmtree(stash_dir)
-        stash_path = 'sqlite:///' + os.path.join(stash_dir, 'stash.json')
+        stash_path = os.path.join(stash_dir, 'stash.json')
         try:
             storage = ghost.SQLAlchemyStorage(stash_path)
             assert os.path.isdir(stash_dir) is False
@@ -287,7 +287,7 @@ class TestSQLAlchemyStorage:
         os.chdir(stash_dir)
         stash_path = os.path.join(stash_dir, 'stash.json')
         try:
-            storage = ghost.SQLAlchemyStorage('sqlite:///' + stash_path)
+            storage = ghost.SQLAlchemyStorage(stash_path)
             stash = ghost.Stash(storage)
             assert os.path.isfile(stash_path) is False
             stash.init()
@@ -297,7 +297,7 @@ class TestSQLAlchemyStorage:
             shutil.rmtree(stash_dir)
 
     def test_put(self, stash_path):
-        storage = ghost.SQLAlchemyStorage('sqlite:///' + stash_path)
+        storage = ghost.SQLAlchemyStorage(stash_path)
         storage.init()
         storage.put(dict(
             name='my_key',
@@ -313,7 +313,7 @@ class TestSQLAlchemyStorage:
 
     def test_list(self, stash_path):
         key = {'name': 'my_key'}
-        storage = ghost.SQLAlchemyStorage('sqlite:///' + stash_path)
+        storage = ghost.SQLAlchemyStorage(stash_path)
         storage.init()
         storage.put(key)
         key_list = storage.list()
@@ -321,14 +321,14 @@ class TestSQLAlchemyStorage:
         assert key['name'] == key_list[0]['name']
 
     def test_empty_list(self, stash_path):
-        storage = ghost.SQLAlchemyStorage('sqlite:///' + stash_path)
+        storage = ghost.SQLAlchemyStorage(stash_path)
         storage.init()
         key_list = storage.list()
         assert len(key_list) == 0
 
     def test_get_delete(self, stash_path):
         inserted_key = {'name': 'my_key'}
-        storage = ghost.SQLAlchemyStorage('sqlite:///' + stash_path)
+        storage = ghost.SQLAlchemyStorage(stash_path)
         storage.init()
         storage.put(inserted_key)
         retrieved_key = storage.get('my_key')


### PR DESCRIPTION
You can now directly provide a local path without providing an RFC-1739 connection string. If the `sqlalchemy` backend is chosen, local path would be assumed to be a sqlitedb. You can also provide a `sqlite://...` style connection string or any other connection string for that matter.