### PR TITLE
Disallow using a stash before it is initialized (Removing py26 due to…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ matrix:
   include:
     - env: TOX_ENV=flake8
     - env: TOX_ENV=py3flake8
-    - python: 2.6 # these are just to make travis's UI a bit prettier
-      env: TOX_ENV=py26
     - python: 2.7
       env: TOX_ENV=py27
     - python: 3.3

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ To that end, ghost supports file based backends like TinyDB and SQLite. Using ot
 
 Currently, ghost supports authenticating only via a passphrase. Authenticating via KMS, GitHub and the likes, might be supported in the future.
 
+Note that beginning with v0.6.1, Python 2.6 is no longer provided.
 
 ## Alternatives
 
@@ -32,7 +33,7 @@ Currently, ghost supports authenticating only via a passphrase. Authenticating v
 
 ## Installation
 
-Ghost supports Linux, Windows and OSX on Python 2.6, 2.7 and 3.3+
+Ghost supports Linux, Windows and OSX on Python 2.7 and 3.3+
 
 ```shell
 pip install ghost

--- a/setup.py
+++ b/setup.py
@@ -30,12 +30,11 @@ setup(
     extras_require={
         'vault': ['hvac>=0.2.16'],
         'consul': ['requests>=2.11.1'],
-        'sqlalchemy': ['sqlalchemy>=1.0.15'],
+        'sqlalchemy': ['sqlalchemy>=1.0.15', 'sqlalchemy-utils>=0.32.14'],
         'elasticsearch': ['elasticsearch>=2.4.0']
     },
     classifiers=[
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',

--- a/tests/test_ghost.py
+++ b/tests/test_ghost.py
@@ -1265,6 +1265,15 @@ class TestCLI:
         result = _invoke('put_key aws key=value -p {0}'.format('bad'))
         self._assert_bad_passphrase(result)
 
+    @pytest.mark.skipif(os.name == 'nt', reason='TODO why fails on nt')
+    def test_put_not_initialized(self):
+        # TODO: test this on all backends
+        # TODO: check on windows if bad passphrase is provided
+        result = _invoke('put_key aws key=value')
+        assert type(result.exception) == SystemExit
+        assert result.exit_code == 1
+        assert 'Stash not initialized' in result.output
+
     def test_put_no_modify(self, test_cli_stash):
         _invoke('put_key aws key=value')
         result = _invoke('put_key aws key=value')

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.7.2
-envlist = flake8, py3flake8, py26, py27, py33, py34, py35, py36
+envlist = flake8, py3flake8, py27, py33, py34, py35, py36
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
… sqlalchemy-utils unsupported anymore)

* A user could `put` in a stash before it is initialized which would result in an inaccessible stash because the passphrase wasn't accessible.
* Now we validate that the stash is initialized before trying to perform any action on it.
* Fix initialization and initialization validation in the sqlalchemy and tinydb backends to support this