### PR TITLE
Patch iterations when running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,6 @@ install:
     - pip install tox
     - pip install codecov
 script:
-    - tox -e $TOX_ENV
+    - make testone TOX_ENV="$TOX_ENV"
 after_success:
   - codecov

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,10 @@
 # Name of this package
 PACKAGENAME = ghost
 
+# Default tox env when running `make testone`
+TOX_ENV ?= py36
+
+
 .PHONY: help
 help:
 	@echo 'Please use "make <target>" where <target> is one of'
@@ -44,7 +48,7 @@ test:
 testone:
 	pip install 'tox>=1.7.2'
 	sed -i 's/iterations=1000000/iterations=100/g' ghost.py
-	tox -e py36
+	tox -e $(TOX_ENV)
 	sed -i 's/iterations=100/iterations=1000000/g' ghost.py
 	@echo "$@ done."
 


### PR DESCRIPTION
`make testone` will patch the number of iterations to 100 and reset them to a 1000000 when done. Travis will now use `make testone` and pass the tox env to it for the relevant env.